### PR TITLE
Steel Not Flesh Suggestion for soviet tank

### DIFF
--- a/Spearhead-II-Release-Notes/v1.1.0 - Officer Plan.md
+++ b/Spearhead-II-Release-Notes/v1.1.0 - Officer Plan.md
@@ -227,10 +227,10 @@
       - Slot 2 ability is On the Double!, which increases infantry movement speed, decreases received suppression slightly, and decreases received accuracy, but drastically decreases unit accuracy and fire rate.
       - Slot 3 ability is Stand Fast!, which grants increased infantry fire rate and suppression resistance but also the inability to retreat, reduced unit accuracy, and greatly increased received accuracy.
     - Tank
-      - Hotbar abilities "Counterattack Tactics", "On the Double!", and "Stand Fast!" have been moved to the Major. Abilities "Smoke Raid Operation", "Counterattack Tactics", and "Early Warning" have been removed.
+      - Hotbar abilities "Counterattack Tactics", and "On the Double!" have been moved to the Major. Abilities "Smoke Raid Operation", "Counterattack Tactics", "Stand Fast!" and "Early Warning" have been removed.
       - Slot 1 ability is Counterattack Tactics, which increases neutral territory capture speed and improves line-of-sight, but decreases movement speed in enemy territory.
       - Slot 2 ability is On the Double!, which increases infantry movement speed, decreases received suppression slightly, and decreases received accuracy, but drastically decreases unit accuracy and fire rate.
-      - Slot 3 ability is Stand Fast!, which grants increased infantry fire rate and suppression resistance but also the inability to retreat, reduced unit accuracy, and greatly increased received accuracy.
+      - Slot 3 ability is Steel not Flesh, which massively increass the recieved accuracy of tanks, and massively reduces the recieved accuracy of infantry.
     - Armoured
       - Hotbar abilities "Breakthrough Tactics", "Combined Arms", and "Radio Silence" have been moved to the Major. Abilities "Counter Assault" and Allied War Machine" have been removed.
       - Slot 1 ability is Breakthrough Tactics, which provides a one-time cancelling of active suppression effects, improves territory capture speed of all infantry, nearly eliminates received suppression, and improves movement speed, but increases received accuracy and decreases suppression output.


### PR DESCRIPTION
# About Pull Request
This is a suggestion to replace the ability "Stand Fast!" with the ability of "Steel not Flesh" for British Tank in the officer rework plan, this theoretical ability would massively reduce received accuracy for Infantry units while massively increasing tank received accuracy with no further effects.

- If the ability is too strong...  I would consider adding a accuracy decrease to tank units against other tanks, or a nerf to Infantry accuracy.
                
                
- If the ability is to weak... I would consider adding a damage resistance to infantry units for the duration of the ability.
           
